### PR TITLE
Use Mage_Core_Controller_Front_Action after SUPEE-5994

### DIFF
--- a/src/app/code/community/Ess/M2ePro/controllers/CronController.php
+++ b/src/app/code/community/Ess/M2ePro/controllers/CronController.php
@@ -4,7 +4,7 @@
  * @copyright  Copyright (c) 2013 by  ESS-UA.
  */
 
-class Ess_M2ePro_CronController extends Mage_Core_Controller_Varien_Action
+class Ess_M2ePro_CronController extends Mage_Core_Controller_Front_Action
 {
     //#############################################
 


### PR DESCRIPTION
See https://github.com/firegento/magento/blob/v1.9.1.1%2Bpatch2/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php#L286

Now there is a strict check for the controller instance class. I'm not sure the impact on this extension but perhaps worth a check
